### PR TITLE
Feature:  여러 개의 음식, 영양소 기록을 가능하게 하기 외 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 #environments
 *.sh
 .DS_*
+
+# annotation
+MEMO.md

--- a/back/settings.py
+++ b/back/settings.py
@@ -13,12 +13,18 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 # python manage.py collectstatic
 
 from pathlib import Path
+import environ
 import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+
+ENV = environ.Env(DEBUG=(bool, True))
+
+# Take environment variables from .env file
+environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-j-#j-uzt!fu4fq)=*0$&bv69+yg1px@8!w!hsk*m3r5%d$de0('

--- a/main/views.py
+++ b/main/views.py
@@ -175,7 +175,7 @@ def ImageUpload(request):
             result = []
             for foodname in predicted_name:
                 print(foodname)
-                if foodname == "용기":
+                if foodname == "용기": # !나중에 삭제
                     continue
                 food = Food.objects.get(name=foodname)
                 data = {
@@ -206,22 +206,23 @@ def Result(request):
     if request.method == "POST":
         userid = get_id_from_token(request)  # userid
 
-        predicted = request.POST.get('realFoodName')  # 프론트에서 보낸 예측한 음식 이름 저장
-        print(f"predicted : {predicted}")
-        predicted_data = search(predicted)
+        predicted = request.POST.getlist('realFoodName')[0].split(',')  # 프론트에서 보낸 예측한 음식 이름 저장
+        print(f"음식이름: {predicted}")
+        for pred in predicted:
+            predicted_data = search(pred)
+            print(predicted_data)
 
-        gallery = cache.get('temp')  # 캐시에서 gallery 객체 꺼내옴
-        print(gallery)
+            gallery = cache.get('temp')  # 캐시에서 gallery 객체 꺼내옴
+            print(f"갤러리에서 꺼내옴: {gallery}")
 
-        # 꺼내온 객체 Gallery 테이블에 저장
-        gallery.name = predicted_data['name']
-        gallery.total = predicted_data['total']
-        gallery.kcal = predicted_data['kcal']
-        gallery.pro = predicted_data['pro']
-        gallery.carbon = predicted_data['carbon']
-        gallery.fat = predicted_data['fat']
-
-        gallery.save()
+            # 꺼내온 객체 Gallery 테이블에 저장
+            gallery.name = predicted_data['name']
+            gallery.total = predicted_data['total']
+            gallery.kcal = predicted_data['kcal']
+            gallery.pro = predicted_data['pro']
+            gallery.carbon = predicted_data['carbon']
+            gallery.fat = predicted_data['fat']
+            gallery.save()
 
         return JsonResponse({'message': '최종 업로드 성공'}, status=200)
     return JsonResponse({'error: 잘못된 요청'}, status=400)

--- a/main/views.py
+++ b/main/views.py
@@ -166,7 +166,9 @@ def ImageUpload(request):
         # predict 수행
         uploaded_file_url = handle_uploaded_file(food_image)
         print(f"uploaded_file_url : {uploaded_file_url}")
-        file_path = os.path.join(settings.MEDIA_ROOT, uploaded_file_url.lstrip('/media/'))  # 파일 경로 URL
+        # file_path = os.path.join(settings.MEDIA_ROOT, uploaded_file_url.lstrip('/media/'))  # 파일 경로 URL
+        file_path = os.path.join(settings.MEDIA_ROOT, uploaded_file_url.replace('/media/', ''))  # 파일 경로 URL
+        print(file_path)
 
         predicted_name = prediction(file_path)  # 모델이 예측한 음식 이름 받아옴 (list or string)
         # 업로드 성공
@@ -361,7 +363,7 @@ def prediction(image_path):
     print("-------------------", image_path)
     # FastAPI 호출
     # url = 'http://0.0.0.0:8001/img_object_detection_to_json'
-    url = 'http://host.docker.internal:8001/img_object_detection_to_json'
+    url = f'{settings.ENV("ML_SERVER")}/img_object_detection_to_json'
     files = {'file': (image_path.split("/")[-1], open(image_path, 'rb'), 'image/jpeg')}
     headers = {'accept': 'application/json'}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.9.7
 Pillow
 requests
 django-cors-headers
+django-environ==0.11.2


### PR DESCRIPTION
## Pull Request 요약
- 여러 개의 음식, 영양소 기록을 DB에 등록 가능하게 하기
- ML server 및 환경변수 분리하기 
  - `.env` 추가를 위한 `django-envirion` 적용
- gitignore에 `MEMO.md` 추가 

## 변경 사항

- `main/view.py`의  
  - ML server 주소를 환경변수로 지정
  - `Result()`에 음식 영양소 등록 부분에 for문을 적용