### PR TITLE
Fix: DB server 주소 .env에 추가 & 원하는 날짜에 영양소 업로드 되게 DB 스키마 제약조건 및 코드 수정

### DIFF
--- a/back/settings.py
+++ b/back/settings.py
@@ -99,7 +99,7 @@ DATABASES = {
         'USER': 'admin',
         'PASSWORD': '1234',
         # 'HOST': 'localhost',
-        'HOST': 'host.docker.internal',
+        'HOST': ENV("DB_SERVER"),
         'PORT': '5432',
     }
 }

--- a/main/models.py
+++ b/main/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from accounts.models import Account
+from datetime import datetime
 # Create your models here.
 
 # 사용자별 업로드 정보
@@ -12,7 +13,8 @@ class Gallery(models.Model):
     carbon = models.IntegerField(blank=True, null=True) # 탄수화물
     pro = models.IntegerField(blank=True, null=True) # 단백질
     fat = models.IntegerField(blank=True, null=True) # 지방
-    upload_date = models.DateTimeField(auto_now_add=True) # 이미지 업로드 날짜
+    # upload_date = models.DateTimeField(auto_now_add=True) # 이미지 업로드 날짜
+    upload_date = models.DateTimeField(default=datetime.now()) # 이미지 업로드 날짜
     food_image = models.ImageField(upload_to="media/", blank=True, null=True) # 음식 이미지 파일
 
 


### PR DESCRIPTION
## Pull Request 요약

- DB server 주소도 환경변수이므로 환경변수파일인 .env에 지정하여 환경변수 설정을 더 편리하게 하도록 수정하였음.
- 또, 기존의 백엔드 시스템에서는 캘린더에서 선택한 날짜로 영양소가 업로드 되지 않고, 현재 날짜로만 영양소가 등록되는 문제가 있었음
  - upload_date의 제약조건을 수정하고, 임시 캐시에 선택한 캘린더의 날짜를 저장하고 최종 save시 선택한 날짜로 레코드를 등록하도록 수정함.

## 변경 사항

(코드 변경 사항, 새로운 기능, 수정된 기능, 삭제된 기능 등을 나열)

- .env에 DB_SERVER 환경변수를 추가
- upload_date의 제약조건을` auto_now_add=True` 에서 `default=datetime.now()` 로 수정
- 임시 캐시에 선택한 캘린더의 날짜가 저장되도록 하여 최종 gallery.upload_date에 선택한 날짜가 반영되도록 수정

## 관련 이슈 (optional)

없음.

## 기타 정보(optional)

DB 스키마가 수정되었으므로,
```sh
python manage.py makemigrations
python manage.py migrate
```
를 수행할 것.
